### PR TITLE
Update build-gh-pages.yml

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: hugo --minify --enableGitInfo --baseURL https://mtfwiki.com
       - name: Deploy
-        uses: reggionick/s3-deploy@v3
+        uses: reggionick/s3-deploy@v4
         if: github.ref == 'refs/heads/master'
         with:
           folder: public


### PR DESCRIPTION
"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: reggionick/s3-deploy@v3. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."