### PR TITLE
fix: incorrectly rendered toc item

### DIFF
--- a/content/zh-cn/docs/hrt/puth/pan-bailin/index.md
+++ b/content/zh-cn/docs/hrt/puth/pan-bailin/index.md
@@ -4,7 +4,7 @@ aliases:
   - /zh-cn/docs/hrt/pku3/pan-bailin/
 ---
 
-## 潘{{< ruby 柏 Bǎi >}}林
+## 潘{{% ruby 柏 Bǎi %}}林
 
 {{< doctor-image src="doctor.jpg" >}}
 


### PR DESCRIPTION
This PR fixes the shortcode usage in the TOC item–Say goodbye to "hahahugoshortcode".